### PR TITLE
Limit hash characters to 8 for nicer file names

### DIFF
--- a/src/utils/__tests__/hash.test.js
+++ b/src/utils/__tests__/hash.test.js
@@ -4,10 +4,10 @@ const hash = require('../../utils/hash').default;
 
 test('It hashes an object', () => {
   const obj = { test: 'foo' };
-  expect(hash(obj)).toBe('d39c2c9531fc4e475b3569a9f3c2071c453b982d0fc34a04830d124b7e7b61e9');
+  expect(hash(obj)).toBe('d39c2c95');
 });
 
 test('It hashes a string', () => {
   const str = 'some random value';
-  expect(hash(str)).toBe('2b888fc35f95cfe9ab67340098673ad17054ca7124ebd2eecb23831b05b753e2');
+  expect(hash(str)).toBe('2b888fc3');
 });

--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -4,5 +4,5 @@ export default (data) => {
   const hash = crypto.createHash('sha256');
   hash.update(JSON.stringify(data));
 
-  return hash.digest('hex');
+  return hash.digest('hex').substring(0, 8);;
 };


### PR DESCRIPTION
The probability of a collision when using the first 8 characters is 1 in
64.000 which should be good enough for this use case.

See: https://stackoverflow.com/a/21805494